### PR TITLE
Allow collaborators of a repo to run CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ It will directly install the URL (this do not have to be a task it can be any re
 
 - By default all pull request are denied unless the repo owner is submitting
   them or explictely allowed.
+- Collaborators of a repository are automatically allowed to run the CI.
 - tekton-asa-code will try to find a `OWNERS` file at the root of the `.tekton`
   directory **in the main branch (i.e: main) not in the submitted PR**.
 - If the user who submitted the PR is in that file it will be allowed.

--- a/tektonasacode/github.py
+++ b/tektonasacode/github.py
@@ -18,7 +18,7 @@ import datetime
 import http.client
 import json
 import urllib.parse
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 import pkg_resources
 
@@ -178,6 +178,17 @@ class Github:
         if organization in organizations:
             return True
         return False
+
+    def get_repo_contributors(
+        self,
+        repo_full_name: str,
+    ) -> List[str]:
+        """Get contributors of a repo via API"""
+        _, contributors = self.request(
+            "GET",
+            f"{self.github_api_url}/repos/{repo_full_name}/contributors",
+        )
+        return [x['login'] for x in contributors]
 
     def set_status(
         self,

--- a/tektonasacode/process_templates.py
+++ b/tektonasacode/process_templates.py
@@ -25,6 +25,7 @@ from tektonasacode import config, utils
 
 class Process:
     """Main processing class"""
+
     def __init__(self, github_cls):
         self.utils = utils.Utils()
         self.github = github_cls
@@ -50,6 +51,7 @@ class Process:
         repo_owner = self.utils.get_key("repository.owner.login", jeez)
         owner_repo = self.utils.get_key("pull_request.base.repo.full_name",
                                         jeez)
+        repo_full_name = self.utils.get_key("repository.full_name", jeez)
 
         # Always allow the repo owner to submit.
         if repo_owner == pr_login:
@@ -82,6 +84,9 @@ class Process:
             else:
                 if owner == pr_login:
                     allowed = True
+
+        if pr_login in self.github.get_repo_contributors(repo_full_name):
+            allowed = True
 
         return allowed
 


### PR DESCRIPTION
This fix the chicken and egg issue when we start contributing
.tekton/tekton.yaml file to a new repo.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
